### PR TITLE
Update gobble-rollup to 0.26.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "gobble": "^0.10.2",
     "gobble-cli": "^0.6.0",
     "gobble-leafdoc": "^0.1.7",
-    "gobble-rollup": "^0.25.0",
+    "gobble-rollup": "^0.26.3",
     "rollup-plugin-babel": "^2.4.0"
   }
 }


### PR DESCRIPTION
Fixes Bad sourcemap errors, see
https://github.com/rollup/rollup/issues/618
