### PR TITLE
Remove `eventConstructors` export from Capabilities

### DIFF
--- a/lib/Capabilities.js
+++ b/lib/Capabilities.js
@@ -2,21 +2,6 @@
 // Detects some browser capabilities. Only for internal use, not exposed to the
 // API user.
 
-
-
-// eventConstructors
-// `true` if the browser can run `new Event()`.
-// If `false`, then the library will resort to the (deprecated) `window.createEvent()`
-// and `event.initMouseEvent()`. This is needed for legacy browsers and PhantomJS.
-export var eventConstructors = true;
-
-try {
-	var foo = new Touch({ identifier: 0, target: document });
-// 	var foo = new MouseEvent();
-} catch(e) {
-	eventConstructors = false;
-}
-
 // touchConstructor, for Touch
 export var touchConstructor = true;
 


### PR DESCRIPTION
Removes the `eventConstructors` export that detects support for constructing events. This variable is never used and support for [event constructor](https://developer.mozilla.org/en-US/docs/Web/API/Event/Event#browser_compatibility) is widely available in all browsers.