### PR TITLE
Remove `mouseEventConstructor` export from Capabilities

### DIFF
--- a/lib/Capabilities.js
+++ b/lib/Capabilities.js
@@ -17,16 +17,6 @@ try {
 	eventConstructors = false;
 }
 
-// mouseEventConstructor, for MouseEvent
-export var mouseEventConstructor = true;
-
-try {
-	var foo = new MouseEvent('mousedown');
-} catch(e) {
-	mouseEventConstructor = false;
-}
-
-
 // touchConstructor, for Touch
 export var touchConstructor = true;
 

--- a/lib/Finger.js
+++ b/lib/Finger.js
@@ -479,43 +479,19 @@ export default class Finger {
 	// 🖑method private_asMouseEvent(evType: String): PointerEvent
 	// Returns an instance of `PointerEvent` representing the current state of the finger
 	_asMouseEvent(evType) {
-		var ev;
-		if (capabilities.mouseEventConstructor) {
-			ev = new MouseEvent('mouse' + evType, {
-				bubbles: true,
-				button:  0,	// Moz doesn't use -1 when no buttons are pressed, WTF?
-				buttons: this._state.down ? 1 : 0,
-				detail:  (evType === 'down' || evType === 'up') ? 1 : 0,	// TODO: count consecutive clicks
-				clientX: this._state.x,
-				clientY: this._state.y,
-				screenX: this._state.x,	/// TODO: Handle page scrolling
-				screenY: this._state.y,
-				pageX:   this._state.x,
-				pageY:   this._state.y,
-	// 			target: document.elementFromPoint(this._state.x, this._state.y),	// works with viewport coords
-			});
-		} else {
-			// For legacy browsers and PhantomJS
-			ev = document.createEvent('MouseEvent');
-			ev.initMouseEvent(
-				'mouse' + evType,	// Type
-				true,	// canBubble
-				true,	// cancellable
-				window,	// view
-				0,	// detail
-				this._state.x,	// screenX
-				this._state.y,	// screenY
-				this._state.x,	// clientX
-				this._state.y,	// clientY
-				false,	// ctrlKey
-				false,	// altKey
-				false,	// shiftKey
-				false,	// metaKey
-				0,	// button
-				null	// relatedTarget
-			);
-		}
-		return ev;
+		return new MouseEvent('mouse' + evType, {
+			bubbles: true,
+			button:  0,	// Moz doesn't use -1 when no buttons are pressed, WTF?
+			buttons: this._state.down ? 1 : 0,
+			detail:  (evType === 'down' || evType === 'up') ? 1 : 0,	// TODO: count consecutive clicks
+			clientX: this._state.x,
+			clientY: this._state.y,
+			screenX: this._state.x,	/// TODO: Handle page scrolling
+			screenY: this._state.y,
+			pageX:   this._state.x,
+			pageY:   this._state.y,
+// 			target: document.elementFromPoint(this._state.x, this._state.y),	// works with viewport coords
+		});
 	}
 
 


### PR DESCRIPTION
Removes the `mouseEventConstructor` export that detects support for constructing mouse events. This variable is no longer needed as the [`MouseEvent` constructor](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/MouseEvent#browser_compatibility) is widely supported in all browsers.