### PR TITLE
Remove `mouse` export from Capabilities

### DIFF
--- a/lib/Capabilities.js
+++ b/lib/Capabilities.js
@@ -57,10 +57,6 @@ try {
 	pointerEventConstructor = false;
 }
 
-
-// mouse: `true` if the browser implements `MouseEvent`
-export var mouse = !!('MouseEvent' in window);
-
 // touch: `true` if the browser implements `TouchEvent`
 export var touch = !!('TouchEvent' in window);
 

--- a/lib/Finger.js
+++ b/lib/Finger.js
@@ -117,9 +117,6 @@ export default class Finger {
 		} else {
 			this._mode = 'mouse';
 			this._initGraphicCircle();
-			if (!capabilities.mouse) {
-				console.warn('This browser cannot emulate mouse events.');
-			}
 		}
 
 


### PR DESCRIPTION
Removes the `mouse` export that detects support for mouse events. This variable is no longer needed as the [`MouseEvent` constructor](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/MouseEvent) is widely supported in all browsers.