### PR TITLE
Remove `pointer` export from Capabilities

### DIFF
--- a/lib/Capabilities.js
+++ b/lib/Capabilities.js
@@ -64,9 +64,6 @@ export var mouse = !!('MouseEvent' in window);
 // touch: `true` if the browser implements `TouchEvent`
 export var touch = !!('TouchEvent' in window);
 
-// pointer: `true` if the browser implements `PointerEvent`
-export var pointer = !!('PointerEvent' in window || 'MSPointerEvent' in window);
-
 
 
 

--- a/lib/Finger.js
+++ b/lib/Finger.js
@@ -111,9 +111,6 @@ export default class Finger {
 			} else {
 				this._initGraphicCircle();
 			}
-			if (!capabilities.pointer) {
-				console.warn('This browser cannot emulate pointer events.');
-			}
 		} else {
 			this._mode = 'mouse';
 			this._initGraphicCircle();


### PR DESCRIPTION
Removes the `pointer` export that detects support for pointer events. This variable is no longer needed as [`PointerEvent` ](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent#browser_compatibility) is widely supported in all browsers.