### PR TITLE
Remove dead code for `Touch` construction in Chrome

### DIFF
--- a/lib/Capabilities.js
+++ b/lib/Capabilities.js
@@ -73,6 +73,6 @@ export var pointer = !!('PointerEvent' in window || 'MSPointerEvent' in window);
 // Some bits borrowed from Leaflet's L.Browser
 const ua = navigator.userAgent.toLowerCase();
 const webkit        = ua.includes('webkit');
-export const chrome = ua.includes('chrome');
+const chrome =        ua.includes('chrome');
 export const gecko  = ua.includes('gecko') && !webkit;
 export const safari = !chrome && ua.includes('safari');

--- a/lib/Finger.js
+++ b/lib/Finger.js
@@ -426,23 +426,7 @@ export default class Finger {
 			});
 		} else {
 
-			if (capabilities.chrome) {
-				touch = document.createTouch(
-					window,	// view
-					this._touchTargetWhenDowned,	// target
-					this._id,	// identifier
-					this._state.x,	// clientX
-					this._state.y,	// clientY
-					this._state.x,	// screenX
-					this._state.y,	// screenY
-
-					// Inconsistency: These break anything other than chrome:
-					25,	// radiusX
-					25,	// radiusY
-					0,	// rotationAngle
-					this._state.pressure	// force
-				);
-			} else if (capabilities.gecko) {
+			if (capabilities.gecko) {
 				touch = document.createTouch(
 					window,	// view
 					this._touchTargetWhenDowned,	// target


### PR DESCRIPTION
Since the [`Touch` constructor](https://developer.mozilla.org/en-US/docs/Web/API/Touch/Touch#browser_compatibility) is now supported in Chrome it is no longer required to fall back to `createTouch()`.