### PR TITLE
Clean up browser detection code

### DIFF
--- a/lib/Capabilities.js
+++ b/lib/Capabilities.js
@@ -71,22 +71,8 @@ export var pointer = !!('PointerEvent' in window || 'MSPointerEvent' in window);
 
 
 // Some bits borrowed from Leaflet's L.Browser
-
-var ua = navigator.userAgent.toLowerCase(),
-    ie = 'ActiveXObject' in window,
-    webkit    = ua.indexOf('webkit') !== -1,
-    phantomjs = ua.indexOf('phantom') !== -1,
-    android23 = ua.search('android [23]') !== -1,
-    chrome    = ua.indexOf('chrome') !== -1,
-    gecko     = ua.indexOf('gecko') !== -1  && !webkit && !window.opera && !ie;
-
-export var phantomjs = phantomjs;
-export var ie = ie;
-export var ielt9 = ie && !document.addEventListener;
-export var edge = 'msLaunchUri' in navigator && !('documentMode' in document);
-export var webkit = webkit;
-export var gecko = gecko;
-export var android = ua.indexOf('android') !== -1;
-export var android23 = android23;
-export var chrome = chrome;
-export var safari = !chrome && !phantomjs && ua.indexOf('safari') !== -1;
+const ua = navigator.userAgent.toLowerCase();
+const webkit        = ua.includes('webkit');
+export const chrome = ua.includes('chrome');
+export const gecko  = ua.includes('gecko') && !webkit;
+export const safari = !chrome && ua.includes('safari');


### PR DESCRIPTION
Cleans up the browser detection code so all unsupported platforms are removed (Internet Explorer, PhantomJS, Legacy Android, Legacy Edge), and ensures only the variables used in the rest of the code are exported.