### PR TITLE
Include Leaflet as a development dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,21 +8,19 @@
       "name": "prosthetic-hand",
       "version": "1.4.0",
       "license": "Beerware",
-      "dependencies": {
-        "leaflet": "^1.9.3"
-      },
       "devDependencies": {
         "http-server": "^14.1.1",
-        "leafdoc": "^2.3.0"
+        "leafdoc": "^2.3.0",
+        "leaflet": "^1.9.4"
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.21.5.tgz",
-      "integrity": "sha512-FRqFlFKNazWYykft5zvzuEl1YyTDGsIRrjV9rvxvYkUC7W/ueBng1X68Xd6uRMzAaJ0xMKn08/wem5YS1lpX8w==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.22.5.tgz",
+      "integrity": "sha512-TNPDN6aBFaUox2Lu+H/Y1dKKQgr4ucz/FGyCz67RVYLsBpVpUFf1dDngzg+Od8aqbrqwyztkaZjtWCZEUOT8zA==",
       "dev": true,
       "dependencies": {
-        "core-js-pure": "^3.25.1",
+        "core-js-pure": "^3.30.2",
         "regenerator-runtime": "^0.13.11"
       },
       "engines": {
@@ -372,7 +370,8 @@
     "node_modules/leaflet": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
-      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "dev": true
     },
     "node_modules/line-counter": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,7 @@
   "license": "Beerware",
   "devDependencies": {
     "http-server": "^14.1.1",
-    "leafdoc": "^2.3.0"
-  },
-  "dependencies": {
-    "leaflet": "^1.9.3"
+    "leafdoc": "^2.3.0",
+    "leaflet": "^1.9.4"
   }
 }


### PR DESCRIPTION
I accidentally included Leaflet as a regular dependency under #25. This PR moves it to the development dependencies so it's not installed when users try to install the package.