### PR TITLE
Replace hand emoji with one Reccomended for General Interchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# 🖑 prosthetic-hand 🖑
+# 🖐️ prosthetic-hand 🖐️
 
 A JavaScript library to emulate mouse/touch/pointer events, designed to help unit-test touch gestures.
 

--- a/lib/Finger.js
+++ b/lib/Finger.js
@@ -8,12 +8,12 @@ import * as capabilities from './Capabilities.js';
 //   ID whenever they go down.
 var fingerIdSequence = 1;
 
-// 🖑class Finger
+// 🖐️class Finger
 // Represents a finger, capable of performing single touch/pointer/mouse synthetic
 // events.
 
 /*
-🖑example
+🖐️example
 
 ```js
 var h = new Hand();
@@ -26,7 +26,7 @@ fatFinger.wait(500).moveTo(200, 250, 0).down().moveBy(100, 150, 2000).up();
 */
 export default class Finger {
 
-	// 🖑factory Finger(eventMode: String, options?: Finger state): Finger
+	// 🖐️factory Finger(eventMode: String, options?: Finger state): Finger
 	// Instantiates a new `Finger`. `eventMode` must be `mouse`, `touch` or `pointer`
 	// for `MouseEvent`s, `TouchEvent`s or `PointerEvent`s, respectively.
 	constructor(eventMode, options) {
@@ -40,36 +40,36 @@ export default class Finger {
 		/// TODO: parkinsonFactor or shakesFactor or jitteryness or something
 
 
-		// 🖑section Finger state
+		// 🖐️section Finger state
 		// The internal state of a `Finger` has options which will be reflected as
 		// properties of the events fired afterwards. Some of these state options
 		// apply only to a specific event mode.
 		this._state = Object.assign({}, {
-			// 🖑option x: Number; The number of pixels from the left boundary the finger is at.
+			// 🖐️option x: Number; The number of pixels from the left boundary the finger is at.
 			x: 0,
 
-			// 🖑option y: Number; The number of pixels from the top boundary the finger is at.
+			// 🖐️option y: Number; The number of pixels from the top boundary the finger is at.
 			y: 0,
 
-			// 🖑option down: Boolean; Whether the finger is down (clicking/touching/pressing) or not. This is referred to as "active" in some of the events specifications.
+			// 🖐️option down: Boolean; Whether the finger is down (clicking/touching/pressing) or not. This is referred to as "active" in some of the events specifications.
 			down: false,
 
-			// 🖑option pressure: Number = 0.5; The value for [`Touch.force`](`https://developer.mozilla.org/docs/Web/API/Touch/force`) or [`PointerEvent.pressure`](https://developer.mozilla.org/docs/Web/API/PointerEvent/pressure), between `0.0` and `1.0`
+			// 🖐️option pressure: Number = 0.5; The value for [`Touch.force`](`https://developer.mozilla.org/docs/Web/API/Touch/force`) or [`PointerEvent.pressure`](https://developer.mozilla.org/docs/Web/API/PointerEvent/pressure), between `0.0` and `1.0`
 			pressure: 0.5,
 
-			// 🖑option tiltX: Number = 0; The value for [`PointerEvent.tiltX`](https://developer.mozilla.org/docs/Web/API/PointerEvent/tiltX)
+			// 🖐️option tiltX: Number = 0; The value for [`PointerEvent.tiltX`](https://developer.mozilla.org/docs/Web/API/PointerEvent/tiltX)
 			tiltX: 0,
 
-			// 🖑option tiltY: Number = 0; The value for [`PointerEvent.tiltX`](https://developer.mozilla.org/docs/Web/API/PointerEvent/tiltY)
+			// 🖐️option tiltY: Number = 0; The value for [`PointerEvent.tiltX`](https://developer.mozilla.org/docs/Web/API/PointerEvent/tiltY)
 			tiltY: 0,
 
-			// 🖑option width: Number = 25; The value for [`Touch.radiusX`](`https://developer.mozilla.org/docs/Web/API/Touch/radiusX`) or [`PointerEvent.width`](https://developer.mozilla.org/docs/Web/API/PointerEvent/width)
+			// 🖐️option width: Number = 25; The value for [`Touch.radiusX`](`https://developer.mozilla.org/docs/Web/API/Touch/radiusX`) or [`PointerEvent.width`](https://developer.mozilla.org/docs/Web/API/PointerEvent/width)
 			width: 25,
 
-			// 🖑option radiusY: Number = 25; The value for [`Touch.radiusY`](`https://developer.mozilla.org/docs/Web/API/Touch/radiusY`) or [`PointerEvent.height`](https://developer.mozilla.org/docs/Web/API/PointerEvent/height)
+			// 🖐️option radiusY: Number = 25; The value for [`Touch.radiusY`](`https://developer.mozilla.org/docs/Web/API/Touch/radiusY`) or [`PointerEvent.height`](https://developer.mozilla.org/docs/Web/API/PointerEvent/height)
 			height: 25,
 
-			// 🖑option pointerType: String = 'pen'; The value for [`PointerEvent.pointerType`](https://developer.mozilla.org/docs/Web/API/PointerEvent/pointerType)
+			// 🖐️option pointerType: String = 'pen'; The value for [`PointerEvent.pointerType`](https://developer.mozilla.org/docs/Web/API/PointerEvent/pointerType)
 			pointerType: 'pen'
 		}, options);
 
@@ -129,28 +129,28 @@ export default class Finger {
 	}
 
 
-	// 🖑method isIdle(): Boolean
+	// 🖐️method isIdle(): Boolean
 	// Returns true when the finger has no more pending movements/waits/wiggles/etc.
 	isIdle() {
 		return !(this._movements.length);
 	}
 
 
-	// 🖑method down(delay?: Number): this
+	// 🖐️method down(delay?: Number): this
 	// Puts the finger down, optionally after a delay.
 	down(delay) {
 		return this.update({ down: true, getState: this._falseFn, duration: delay || 0 });
 	}
 
 
-	// 🖑method up(options?: {}): this
+	// 🖐️method up(options?: {}): this
 	// Lifts the finger up, after an optional delay.
 	up(delay) {
 		return this.update({ down: false, getState: this._falseFn, duration: delay || 0 });
 	}
 
 
-	// 🖑method wait(delay): this
+	// 🖐️method wait(delay): this
 	// Don't move this finger for `delay` milliseconds.
 	wait(delay) {
 		this._queueMove({finalState: this._finalState, getState: this._falseFn, duration: delay});
@@ -158,7 +158,7 @@ export default class Finger {
 	}
 
 
-	// 🖑method waitUntil(timestamp): this
+	// 🖐️method waitUntil(timestamp): this
 	// Don't move this finger until the given timestamp is reached.
 	waitUntil(timestamp) {
 		if (this._movements.length) {
@@ -179,7 +179,7 @@ export default class Finger {
 	}
 
 
-	// 🖑method update(options?: {}): this
+	// 🖐️method update(options?: {}): this
 	// Updates some of the finger options, like pressure or touch angle,
 	// without disturbing its movement, after an optional delay.
 	update(options, delay) {
@@ -188,7 +188,7 @@ export default class Finger {
 	}
 
 
-	// 🖑method reset(options?: {}): this
+	// 🖐️method reset(options?: {}): this
 	// Clears all the queued movements for this finger and immediately lifts it up
 	reset(options) {
 		return this;
@@ -196,7 +196,7 @@ export default class Finger {
 
 
 
-	// 🖑method moveTo(x: Number, y: Number, delay: Number, options?: {}): this
+	// 🖐️method moveTo(x: Number, y: Number, delay: Number, options?: {}): this
 	// Queues moving this finger to an absolute position at `(x, y)`; the
 	// movement will last for `delay` milliseconds.
 	moveTo(x, y, delay) {
@@ -204,7 +204,7 @@ export default class Finger {
 	}
 
 
-	// 🖑method moveBy(x: Number, y: Number, delay: Number, options?: {}): this
+	// 🖐️method moveBy(x: Number, y: Number, delay: Number, options?: {}): this
 	// Queues a move of this finger to an position relative to its last position
 	// plus`(x, y)`; the movement will last for `delay` milliseconds.
 	moveBy(x, y, delay) {
@@ -264,7 +264,7 @@ export default class Finger {
 
 
 	// Returns the timestamp when the next movement will be finished
-	// 🖑method getNextMoveEndTime(): Number|undefined
+	// 🖐️method getNextMoveEndTime(): Number|undefined
 	getNextMoveEndTime() {
 		if (!this._movements.length) {
 			return undefined;
@@ -274,7 +274,7 @@ export default class Finger {
 
 
 	/*
-	 * 🖑method getEvents(timestamp?: Number, justOne: Boolean): []
+	 * 🖐️method getEvents(timestamp?: Number, justOne: Boolean): []
 	 * Updates the private properties of the finger (x, y, timestamp) by
 	 * running the next movement(s) as far as indicated by the timestamp (or
 	 * as fas as to `performance.now()`), then checks if the state has changed
@@ -397,7 +397,7 @@ export default class Finger {
 
 
 
-	// 🖑method private_asTouch(): Touch
+	// 🖐️method private_asTouch(): Touch
 	// Returns an instance of `Touch` representing the current state of the finger
 	// Note this is not an event - a `TouchEvent` must be created later, with several
 	// `Touch`es.
@@ -450,7 +450,7 @@ export default class Finger {
 		return touch;
 	}
 
-	// 🖑method private_asPointerEvent(): PointerEvent
+	// 🖐️method private_asPointerEvent(): PointerEvent
 	// Returns an instance of `PointerEvent` representing the current state of the finger
 	_asPointerEvent(evType) {
 		return new PointerEvent('pointer' + evType, {
@@ -476,7 +476,7 @@ export default class Finger {
 		});
 	}
 
-	// 🖑method private_asMouseEvent(evType: String): PointerEvent
+	// 🖐️method private_asMouseEvent(evType: String): PointerEvent
 	// Returns an instance of `PointerEvent` representing the current state of the finger
 	_asMouseEvent(evType) {
 		return new MouseEvent('mouse' + evType, {

--- a/lib/Hand.js
+++ b/lib/Hand.js
@@ -10,11 +10,11 @@ const TimingMode = {
 	FastFrame: 'FAST_FRAME'
 };
 
-// 🖑class Hand
+// 🖐️class Hand
 // Represents a set of `Finger`s, capable of performing synthetic touch gestures
 
 /*
-🖑example
+🖐️example
 
 ```js
 var h = new Hand({ timing: '20ms' });
@@ -23,7 +23,7 @@ var h = new Hand({ timing: '20ms' });
 */
 export default class Hand {
 
-	// 🖑factory Hand(options?: Hand options): Hand
+	// 🖐️factory Hand(options?: Hand options): Hand
 	// Instantiates a new `Hand` with the given options.
 	constructor(options) {
 
@@ -38,18 +38,18 @@ export default class Hand {
 
 		/// TODO: Timing modes: minimal, interval, frames
 
-		// 🖑option timing: Timing= '20ms'
+		// 🖐️option timing: Timing= '20ms'
 		// Defines how often new events will be fired, in one of the possible
 		// timing modes
 
-		// 🖑miniclass Timing (Hand)
+		// 🖐️miniclass Timing (Hand)
 		this._timeInterval = 20;
 		this._timingMode = TimingMode.Interval;
 		this._framesPending = 0;
 		if (options.timing) {
 			var timing = options.timing.toString();
 
-			// 🖑option ms
+			// 🖐️option ms
 			// Preceded by a number (e.g. `'20ms'`), this mode triggers an event
 			// dispatch every that many milliseconds.
 			if (timing.match(/^\d+ms$/)) {
@@ -57,14 +57,14 @@ export default class Hand {
 				this._timeInterval = parseInt(timing);
 			}
 
-			// 🖑option frame
+			// 🖐️option frame
 			// This mode dispatches an event every [animation frame](https://developer.mozilla.org/docs/Web/API/Window/requestAnimationFrame).
 			if (timing === 'frame') {
 				this._timingMode = TimingMode.Frame;
 				this._timeInterval = parseInt(timing);
 			}
 
-			// 🖑option minimal
+			// 🖐️option minimal
 			// This mode triggers an event dispatch per finger change, and ensures
 			// that every move can trigger its own event (no two movements will be
 			// rolled into one event if they are very close).
@@ -73,7 +73,7 @@ export default class Hand {
 				this._timeInterval = false;
 			}
 
-			// 🖑option instant
+			// 🖐️option instant
 			// Like the `minimal` mode, but ignores timings completely and dispatches
 			// all events instantaneously. This might cause misbehaviour in graphical
 			// browsers, and the `onStart` and `onStop` callbacks will be called at.
@@ -84,7 +84,7 @@ export default class Hand {
 				this._timeInterval = false;
 			}
 
-			// 🖑option fastframe
+			// 🖐️option fastframe
 			// This mode ignores timings completely like the `instant` mode, and
 			// dispatches a new event every so many frames.
 			if (timing === 'fastframe') {
@@ -93,16 +93,16 @@ export default class Hand {
 			}
 		}
 		
-		// 🖑class Hand
+		// 🖐️class Hand
 
-		// 🖑option onStart: Function
+		// 🖐️option onStart: Function
 		// If set to a callback function, it will be called (with the `Hand` 
 		// as its only argument) whenever the movements start.
 		if (options.onStart) {
 			this._onStart = options.onStart;
 		}
 		
-		// 🖑option onStop: Function
+		// 🖐️option onStop: Function
 		// If set to a callback function, it will be called (with the `Hand` 
 		// as its only argument) whenever the movements are completed.
 		if (options.onStop) {
@@ -117,7 +117,7 @@ export default class Hand {
 	}
 
 
-	// 🖑method growFinger(eventMode, options): Finger
+	// 🖐️method growFinger(eventMode, options): Finger
 	// Creates a new `Finger` with the same parameters as the [`Finger` constructor](#finger-finger),
 	// and adds it to the hand.
 	growFinger(fingerMode, options) {
@@ -136,7 +136,7 @@ export default class Hand {
 
 
 
-	// 🖑method fingerIsBusy(): this
+	// 🖐️method fingerIsBusy(): this
 	// Used by this hand's fingers to signal that there are movements to be
 	// performed by at least one finger.
 	fingerIsBusy() {
@@ -144,10 +144,10 @@ export default class Hand {
 		/// TODO: Start up the event loop
 
 		if (this._fingersAreIdle) {
-			// 🖑section
+			// 🖐️section
 			// Use `document.addEventListener('prostheticHandStop', fn)` to
 			// do stuff with it.
-			// 🖑event prostheticHandStart: CustomEvent
+			// 🖐️event prostheticHandStart: CustomEvent
 			// Fired when all movements are complete.
 			document.dispatchEvent(new CustomEvent('prostheticHandStart', {target: this}));
 
@@ -162,7 +162,7 @@ export default class Hand {
 		return this;
 	}
 
-	// 🖑method fingerIsIdle(): this
+	// 🖐️method fingerIsIdle(): this
 	// Used by this hand's fingers to signal that one finger has finished doing
 	// all the queued movements.
 	fingerIsIdle() {
@@ -173,7 +173,7 @@ export default class Hand {
 	}
 
 
-	// 🖑method sync(delay): this
+	// 🖐️method sync(delay): this
 	// Synchronizes the finger movements by adding a delay of **at least** `delay`
 	// milliseconds to each finger. After a sync, the movements of the fingers
 	// will happen at exactly the same time.
@@ -199,13 +199,13 @@ export default class Hand {
 
 
 
-	// 🖑method private_dispatchEvents(): this
+	// 🖐️method private_dispatchEvents(): this
 	// Updates all the fingers, fetching their events/touchpoints, and dispatches
 	// all `Event`s triggered by the update.
 	// This is meant to be called on an internal timer.
 	_dispatchEvents(timestamp) {
 
-		// 🖑event prostheticHandTick: CustomEvent
+		// 🖐️event prostheticHandTick: CustomEvent
 		// Fired a movement is about to start, just before the mouse/touch/pointer
 		// events are fired.
 		document.dispatchEvent(new CustomEvent('prostheticHandStart', {target: this}));
@@ -446,7 +446,7 @@ export default class Hand {
 
 	_scheduleNextDispatch(){
 		if (this._fingersAreIdle) {
-			// 🖑event prostheticHandStop: CustomEvent
+			// 🖐️event prostheticHandStop: CustomEvent
 			// Fired when all movements are complete.
 
 			document.dispatchEvent(new CustomEvent('prostheticHandStop', {target: this}));

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "start": "http-server .",
-    "build-docs": "leafdoc --template node_modules/leafdoc/templates/basic --character 🖑 --output api-docs.html lib"
+    "build-docs": "leafdoc --template node_modules/leafdoc/templates/basic --character 🖐️ --output api-docs.html lib"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Replaces the "Reversed Raised Hand with Fingers Splayed" emoji with the "Hand with Fingers Splayed" emoji. The former is not Recommended For General Interchange ([RGI](https://emojipedia.org/glossary/#rgi)), a.k.a widely supported on all platforms.